### PR TITLE
add type to method option

### DIFF
--- a/lib/acmesmith/command.rb
+++ b/lib/acmesmith/command.rb
@@ -156,7 +156,7 @@ module Acmesmith
     end
 
     desc "autorenew", "request renewal of certificates which expires soon"
-    method_option :days, aliases: %w(-d), default: 7, desc: 'specify threshold in days to select certificates to renew'
+    method_option :days, type: :numeric, aliases: %w(-d), default: 7, desc: 'specify threshold in days to select certificates to renew'
     def autorenew
       storage.list_certificates.each do |cn|
         puts "=> #{cn}"


### PR DESCRIPTION
fix the warning ```Expected string default value for '--days'; got 7 (numeric)```