### PR TITLE
don't crash when no post issueing hooks are defined

### DIFF
--- a/lib/acmesmith/command.rb
+++ b/lib/acmesmith/command.rb
@@ -225,8 +225,10 @@ module Acmesmith
 
     def execute_post_issue_hooks(common_name)
       post_issues_hooks_for_common_name = config.post_issueing_hooks(common_name)
-      post_issues_hooks_for_common_name.each do |hook|
-        hook.execute
+      if post_issues_hooks_for_common_name
+        post_issues_hooks_for_common_name.each do |hook|
+          hook.execute
+        end
       end
     end
 

--- a/lib/acmesmith/config.rb
+++ b/lib/acmesmith/config.rb
@@ -45,11 +45,13 @@ module Acmesmith
 
     def post_issueing_hooks(common_name)
       @post_issueing_hooks ||= begin
-        specs = @config['post_issueing_hooks'][common_name]
-        specs.flat_map do |specs_sub|
-          specs_sub[specs_sub.flatten[0]]['common_name'] = common_name
-          specs_sub.map do |k, v|
-            PostIssueingHooks.find(k).new(**v.map{ |k_,v_| [k_.to_sym, v_]}.to_h)
+        if @config.key?('post_issueing_hooks') && @config['post_issueing_hooks'].key?(common_name)
+          specs = @config['post_issueing_hooks'][common_name]
+          specs.flat_map do |specs_sub|
+            specs_sub[specs_sub.flatten[0]]['common_name'] = common_name
+            specs_sub.map do |k, v|
+              PostIssueingHooks.find(k).new(**v.map{ |k_,v_| [k_.to_sym, v_]}.to_h)
+            end
           end
         end
       end

--- a/spec/acmesmith_spec.rb
+++ b/spec/acmesmith_spec.rb
@@ -12,12 +12,15 @@ describe Acmesmith do
     expect { Acmesmith::Command.start(args) }.to output(/authz/).to_stdout
   end
 
-  it 'should merge and execute post issueing hooks' do
+  it 'should execute when no hooks are defines' do
+    args = ["post_issue_hooks", "admin.example.com", '-c', 'spec/config.no_hooks.mock.yml']
+    expect { Acmesmith::Command.start(args) }.to output(//).to_stdout
+  end
 
+  it 'should merge and execute post issueing hooks' do
     args = ["post_issue_hooks", "admin.example.com", '-c', 'spec/config.mock.yml']
     expect { Acmesmith::Command.start(args) }.to output(/Running: echo \$COMMON_NAME > \/tmp\/step003-/).to_stdout
     content = File.read("/tmp/step003-admin.example.com")
-
     expect(content).to eq("admin.example.com\n")
   end
 

--- a/spec/config.no_hooks.mock.yml
+++ b/spec/config.no_hooks.mock.yml
@@ -1,0 +1,11 @@
+endpoint: https://acme-staging.api.letsencrypt.org/
+
+storage:
+   type: filesystem
+   path: ./test/storage
+
+challenge_responders:
+  - route53: {}
+
+account_key_passphrase: password
+certificate_key_passphrase: secret


### PR DESCRIPTION
I forgot to test without the post issueing hooks configuration. Add this to prevent below.

```
bundler: failed to load command: acmesmith (/root/acmesmith-webserverauth/vendor/ruby/2.2.0/bin/acmesmith)
NoMethodError: undefined method `[]' for nil:NilClass
  /root/acmesmith-webserverauth/vendor/ruby/2.2.0/bundler/gems/acmesmith-4569b900481c/lib/acmesmith/config.rb:48:in `post_issueing_hooks'
  /root/acmesmith-webserverauth/vendor/ruby/2.2.0/bundler/gems/acmesmith-4569b900481c/lib/acmesmith/command.rb:227:in `execute_post_issue_hooks'
  /root/acmesmith-webserverauth/vendor/ruby/2.2.0/bundler/gems/acmesmith-4569b900481c/lib/acmesmith/command.rb:68:in `request'
  /root/acmesmith-webserverauth/vendor/ruby/2.2.0/gems/thor-0.19.4/lib/thor/command.rb:27:in `run'
  /root/acmesmith-webserverauth/vendor/ruby/2.2.0/gems/thor-0.19.4/lib/thor/invocation.rb:126:in `invoke_command'
  /root/acmesmith-webserverauth/vendor/ruby/2.2.0/gems/thor-0.19.4/lib/thor.rb:369:in `dispatch'
  /root/acmesmith-webserverauth/vendor/ruby/2.2.0/gems/thor-0.19.4/lib/thor/base.rb:444:in `start'
  /root/acmesmith-webserverauth/vendor/ruby/2.2.0/bundler/gems/acmesmith-4569b900481c/bin/acmesmith:4:in `<top (required)>'
  /root/acmesmith-webserverauth/vendor/ruby/2.2.0/bin/acmesmith:23:in `load'
  /root/acmesmith-webserverauth/vendor/ruby/2.2.0/bin/acmesmith:23:in `<top (required)>'
```