### PR TITLE
Don't pass passphrase when passphrase isn't set

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
 rvm:
+  - 2.3.3
   - 2.4.0
 before_install: gem install bundler -v 1.10.6

--- a/lib/acmesmith/account_key.rb
+++ b/lib/acmesmith/account_key.rb
@@ -16,7 +16,7 @@ module Acmesmith
           self.key_passphrase = passphrase 
         else
           begin
-            @private_key = OpenSSL::PKey::RSA.new(@raw_private_key)
+            @private_key = OpenSSL::PKey::RSA.new(@raw_private_key) { nil }
           rescue OpenSSL::PKey::RSAError
             # may be encrypted
           end

--- a/lib/acmesmith/account_key.rb
+++ b/lib/acmesmith/account_key.rb
@@ -16,7 +16,7 @@ module Acmesmith
           self.key_passphrase = passphrase 
         else
           begin
-            @private_key = OpenSSL::PKey::RSA.new(@raw_private_key, '')
+            @private_key = OpenSSL::PKey::RSA.new(@raw_private_key)
           rescue OpenSSL::PKey::RSAError
             # may be encrypted
           end

--- a/lib/acmesmith/certificate.rb
+++ b/lib/acmesmith/certificate.rb
@@ -33,7 +33,7 @@ module Acmesmith
           self.key_passphrase = key_passphrase 
         else
           begin
-            @private_key = OpenSSL::PKey::RSA.new(@raw_private_key)
+            @private_key = OpenSSL::PKey::RSA.new(@raw_private_key) { nil }
           rescue OpenSSL::PKey::RSAError
             # may be encrypted
           end

--- a/lib/acmesmith/certificate.rb
+++ b/lib/acmesmith/certificate.rb
@@ -33,7 +33,7 @@ module Acmesmith
           self.key_passphrase = key_passphrase 
         else
           begin
-            @private_key = OpenSSL::PKey::RSA.new(@raw_private_key, '')
+            @private_key = OpenSSL::PKey::RSA.new(@raw_private_key)
           rescue OpenSSL::PKey::RSAError
             # may be encrypted
           end

--- a/spec/account_key_spec.rb
+++ b/spec/account_key_spec.rb
@@ -1,0 +1,53 @@
+require 'acmesmith/account_key'
+
+RSpec.describe Acmesmith::AccountKey do
+  describe '#private_key' do
+    let(:private_key) { OpenSSL::PKey::RSA.generate(2048) }
+
+    context 'with passphrase' do
+      let(:cipher) { OpenSSL::Cipher.new('aes-256-cbc') }
+      let(:passphrase) { 'notasecret' }
+      let(:exported_private_key) { private_key.export(cipher, passphrase) }
+      let(:account_key) { described_class.new(exported_private_key) }
+
+      context 'when correct passphrase is passed' do
+        before do
+          account_key.key_passphrase = passphrase
+        end
+
+        it 'returns private key' do
+          expect(account_key.private_key.to_text).to eq(private_key.to_text)
+        end
+      end
+
+      context 'when wrong passphrase is passed' do
+        it 'raises RSAError' do
+          expect { account_key.key_passphrase = 'wrong-passphrase' }.to raise_error(OpenSSL::PKey::RSAError)
+        end
+      end
+
+      context "when passphrase isn't passed" do
+        it 'raises PassphraseRequired' do
+          expect { account_key.private_key }.to raise_error(Acmesmith::AccountKey::PassphraseRequired)
+        end
+      end
+    end
+
+    context 'without passphrase' do
+      let(:exported_private_key) { private_key.export }
+      let(:account_key) { described_class.new(exported_private_key) }
+
+      context "when passphrase isn't passed" do
+        it 'returns private key' do
+          expect(account_key.private_key.to_text).to eq(private_key.to_text)
+        end
+      end
+
+      context 'when passphrase is passed' do
+        it 'raises error' do
+          expect { account_key.key_passphrase = 'notasecret' }.to raise_error(/already given/)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
openssl gem bundled with Ruby 2.4 raises error when passphrase is empty string.
The correct way is passing `nil` or omitting the passphrase argument.

```
% RBENV_VERSION=2.3.3 ruby -ropenssl -ve 'OpenSSL::PKey::RSA.new(File.read("account.pem"), "")'
ruby 2.3.3p222 (2016-11-21 revision 56859) [x86_64-linux]
% RBENV_VERSION=2.4.0 ruby -ropenssl -ve 'OpenSSL::PKey::RSA.new(File.read("account.pem"), "")'
ruby 2.4.0p0 (2016-12-24 revision 57164) [x86_64-linux]
-e:1:in `initialize': password must be at least 4 bytes (OpenSSL::OpenSSLError)
        from -e:1:in `new'
        from -e:1:in `<main>'
% RBENV_VERSION=2.3.3 ruby -ropenssl -ve 'OpenSSL::PKey::RSA.new(File.read("account.pem"))'
ruby 2.3.3p222 (2016-11-21 revision 56859) [x86_64-linux]
% RBENV_VERSION=2.4.0 ruby -ropenssl -ve 'OpenSSL::PKey::RSA.new(File.read("account.pem"))'
ruby 2.4.0p0 (2016-12-24 revision 57164) [x86_64-linux]
```