### PR TITLE
Retry ACME request on badNonce error

### DIFF
--- a/lib/acmesmith/acme_client.rb
+++ b/lib/acmesmith/acme_client.rb
@@ -1,0 +1,64 @@
+require 'acme-client'
+
+module Acmesmith
+  class AcmeClient
+    # @param account_key [Acmesmith::AccountKey]
+    # @param endpoint [String]
+    def initialize(account_key, endpoint)
+      @acme = Acme::Client.new(private_key: account_key.private_key, endpoint: config['endpoint'])
+    end
+
+    # @param contact [String]
+    def register(contact)
+      retry_once_on_bad_nonce do
+        @acme.register(contact: contact)
+      end
+    end
+
+    # @param domain [String]
+    def authorize(domain)
+      retry_once_on_bad_nonce do
+        @acme.authorize(domain: domain)
+      end
+    end
+
+    # @param csr [Acme::Client::CertificateRequest]
+    def new_certificate(csr)
+      retry_once_on_bad_nonce do
+        @acme.new_certificate(csr)
+      end
+    end
+
+    # @param challenge [Acme::Client::Resources::Challenges::Base]
+    def request_verification(challenge)
+      retry_once_on_bad_nonce do
+        challenge.request_verification
+      end
+    end
+
+    # @param challenge [Acme::Client::Resources::Challenges::Base]
+    def verify_status(challenge)
+      retry_once_on_bad_nonce do
+        challenge.verify_status
+      end
+    end
+
+    private
+
+    def retry_once_on_bad_nonce(&block)
+      retried = false
+      begin
+        block.call
+      rescue Acme::Client::Error::BadNonce => e
+        # Let's Encrypt returns badNonce error when the client sends too-old
+        # nonce. So retry the request once.
+        if retried
+          raise e
+        else
+          retried = true
+          retry
+        end
+      end
+    end
+  end
+end

--- a/lib/acmesmith/acme_client.rb
+++ b/lib/acmesmith/acme_client.rb
@@ -5,7 +5,7 @@ module Acmesmith
     # @param account_key [Acmesmith::AccountKey]
     # @param endpoint [String]
     def initialize(account_key, endpoint)
-      @acme = Acme::Client.new(private_key: account_key.private_key, endpoint: config['endpoint'])
+      @acme = Acme::Client.new(private_key: account_key.private_key, endpoint: endpoint)
     end
 
     # @param contact [String]


### PR DESCRIPTION
Let's Encrypt seems to return badNonce error when the client sends
too-old nonce. Since acme-client uses the nonce returned in the previous
request, the badNonce error could happen when there's a long time
between each request. In Acmesmith, such situation take place when
authorizing a certificate with many SANs and performing many challenge
responses.

Note that acme-client v0.6.1 has a bug reporting a wrong error class. We need this patch to retry badNonce errors correctly.
https://github.com/unixcharles/acme-client/pull/129