### PR TITLE
Allow kms for all certs

### DIFF
--- a/lib/acmesmith/storages/s3.rb
+++ b/lib/acmesmith/storages/s3.rb
@@ -92,12 +92,18 @@ module Acmesmith
         end
 
         if update_current
-          @s3.put_object(
+	  params = {
             bucket: bucket,
             key: certificate_current_key(cert.common_name),
-            content_type: 'text/plain',
             body: cert.version,
-          )
+            content_type: 'text/plain',
+          }
+          if use_kms
+            params[:server_side_encryption] = 'aws:kms'
+            key_id = kms_key_id_certificate_key || kms_key_id
+            params[:ssekms_key_id] = key_id if key_id
+          end
+          @s3.put_object(params)
         end
       end
 

--- a/lib/acmesmith/storages/s3.rb
+++ b/lib/acmesmith/storages/s3.rb
@@ -74,7 +74,7 @@ module Acmesmith
             body: body,
             content_type: content_type,
           }
-          if kms
+          if use_kms
             params[:server_side_encryption] = 'aws:kms'
             key_id = kms_key_id_certificate_key || kms_key_id
             params[:ssekms_key_id] = key_id if key_id


### PR DESCRIPTION
Hi,

I noticed '(Aws::S3::Errors::AccessDenied)' errors when using **use_kms: true**. Looks like the KMS headers were inserted into `params` hash only for the account.pem cert.

1. on `put_certificate` method i changed `kms` to `use_kms` from config file.
2. and on `if update_current` i also added KMS support.

I've issued few certificate with KMS with no errors.
Thanks!
