### PR TITLE
Make the pkcs12 export option include the chain

### DIFF
--- a/lib/acmesmith/certificate.rb
+++ b/lib/acmesmith/certificate.rb
@@ -10,7 +10,7 @@ module Acmesmith
 
     def self.by_issuance(pem_chain, csr)
       pems = split_pems(pem_chain)
-      new(*pems, csr.private_key, nil, csr)
+      new(pems[0], pems[1..-1], csr.private_key, nil, csr)
     end
 
     def initialize(certificate, chain, private_key, key_passphrase = nil, csr = nil)
@@ -48,7 +48,7 @@ module Acmesmith
       when String
         @raw_private_key = private_key
         if key_passphrase
-          self.key_passphrase = key_passphrase 
+          self.key_passphrase = key_passphrase
         else
           begin
             @private_key = OpenSSL::PKey::RSA.new(@raw_private_key) { nil }
@@ -111,7 +111,7 @@ module Acmesmith
     end
 
     def pkcs12(passphrase)
-      OpenSSL::PKCS12.create(passphrase, common_name, private_key, certificate)
+      OpenSSL::PKCS12.create(passphrase, common_name, private_key, certificate, chain)
     end
 
     def export(passphrase, cipher: OpenSSL::Cipher.new('aes-256-cbc'))


### PR DESCRIPTION
Currently, when using the pkcs12 method on a Certificate object, it does
not export the chain in the pkcs12 bundle which can lead to serving the
leaf certificate without the intermediate if you load the pkcs12
directly into a server. This change causes the pkcs12 method to properly
export the chain with the cert and key.

I've also included a fix for a second bug in the Certificate by_issuance
constructor. If there ever were a case where there was more than one
intermediate, this call would have failed. This now properly splits the
chain into the two available parameters in all situations.