### PR TITLE
Support role_arn in hosted_zone_map.

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,14 @@ challenge_responders:
       #   session_token:
       # hosted_zone_map: # hosted zone map (optional); This is to specify exactly one hosted zone to use. This will be required when there are multiple hosted zone with same domain name. Usually
       #   "example.org.": "/hostedzone/DEADBEEF"
+      #   Alternative format: Add support for role_arn. Useful when having zones in multiple accounts.
+      #   "both.example.com.": 
+      #       zone_id: "/hostedzone/8BADFOOD"
+      #       role_arn: "arn:aws:iam::123451234512:role/switched_role"
+      #   "zone_id_only.example.com.": 
+      #       zone_id: "/hostedzone/8BADFOOD"
+      #   "role_arn_only.example.com.": 
+      #       role_arn: "arn:aws:iam::123451234512:role/switched_role"
 ```
 
 ### Post Issuing Hooks

--- a/lib/acmesmith/utils/aws.rb
+++ b/lib/acmesmith/utils/aws.rb
@@ -1,0 +1,15 @@
+module Acmesmith
+  module Utils
+    module Aws
+      def self.addClientCredential(opt, aws_access_key=nil, role_arn=nil)
+        opt[:credentials] = ::Aws::Credentials.new(aws_access_key['access_key_id'], aws_access_key['secret_access_key'], aws_access_key['session_token']) if aws_access_key
+        opt[:credentials] = ::Aws::AssumeRoleCredentials.new(
+          client: ::Aws::STS::Client.new(opt),
+          role_arn: role_arn,
+          role_session_name: "acmesmith"
+        ) if role_arn
+        opt
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add support for role_arn in hosted_zone_map.
Allow role_arn and/or zone_id in the hosted_zone_map entries.
Keep the old format for compatibility.
Extracted Acmesmith::Utils::Aws.addClientCredential .
Fixes issue #36 .