### PR TITLE
route53: add restore_to_original_records option

### DIFF
--- a/docs/challenge_responders/route53.md
+++ b/docs/challenge_responders/route53.md
@@ -21,6 +21,10 @@ challenge_responders:
       ##  Required when you have multiple hosted zones for the same domain name.
       hosted_zone_map: 
         "example.org.": "/hostedzone/DEADBEEF"
+
+      # Restore to original records on cleanup (after domain authorization). Default to false.
+      # Useful when you need to keep existing record as long as possible.
+      restore_to_original_records: true
 ```
 
 ## IAM Policy


### PR DESCRIPTION
Some providers (e.g. ACME through Fastly TLS) expect to keep DNS records for their renewal process. This conflicts when Acmesmith is in use for certificates for same domain names.

Adding restore_to_original_records to attempt restore of original records on cleanup, which can expect to keep such records.

Also, now responder deletes CNAME record in a response change set, when there is an existing CNAME record, because other record sets cannot be exist while a CNAME is present.