### PR TITLE
Support OpenSSL 3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,9 +18,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['2.6', '2.7']
+        ruby-version: ['2.7', '3.0', '3.1']
     container:
-      image: sorah/ruby:${{ matrix.ruby-version }}-dev
+      image: public.ecr.aws/sorah/ruby:${{ matrix.ruby-version }}-dev
     steps:
 
       - name: Cache bundled gems
@@ -40,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['2.6', '2.7']
+        ruby-version: ['2.7', '3.0', '3.1']
 
         # FIXME: once GitHub Actions gains support of adding command line arguments to container
       #    services:
@@ -72,7 +72,7 @@ jobs:
 
       - run: 'docker run -d --net=host --rm letsencrypt/pebble pebble -config /test/config/pebble-config.json -strict -dnsserver 127.0.0.1:8053'
       - run: 'docker run -d --net=host --rm letsencrypt/pebble-challtestsrv pebble-challtestsrv -management :8055 -defaultIPv4 127.0.0.1'
-      - run: 'docker run --net=host -e CI --rm -v $(pwd):/work -v $(realpath ~/bundle):/bundle sorah/ruby:${{ matrix.ruby-version  }}-dev sh -c "cd /work && bundle install --path /bundle && bundle exec rspec -fd -t integration_pebble"'
+      - run: 'docker run --net=host -e CI --rm -v $(pwd):/work -v $(realpath ~/bundle):/bundle public.ecr.aws/sorah/ruby:${{ matrix.ruby-version  }}-dev sh -c "cd /work && bundle install --path /bundle && bundle exec rspec -fd -t integration_pebble"'
 
   docker-build:
     name: docker-build


### PR DESCRIPTION
OpenSSL 3 changed its string representation of authorityKeyIdentifier
 not to include keyid: prefix for keyIdentifier.

This patch removes dependency to string dependency and use DER serialized format to handle key identifiers. However this does not
 support AKI other than key identifier but it should be okay.