### PR TITLE
Support EC / RSA 2048+ certificates

### DIFF
--- a/lib/acmesmith/certificate.rb
+++ b/lib/acmesmith/certificate.rb
@@ -113,6 +113,11 @@ module Acmesmith
       raise PassphraseRequired, 'key_passphrase required'
     end
 
+    # @return [OpenSSL::PKey::PKey]
+    def public_key
+      @certificate.public_key
+    end
+
     # @return [String] leaf certificate + full certificate chain
     def fullchain
       "#{certificate.to_pem}\n#{issuer_pems}".gsub(/\n+/,?\n)

--- a/lib/acmesmith/client.rb
+++ b/lib/acmesmith/client.rb
@@ -208,14 +208,14 @@ module Acmesmith
       case key_type
       when 'rsa'
         OpenSSL::PKey::RSA.generate(rsa_key_size)
-      when 'ecdsa'
+      when 'ec'
         OpenSSL::PKey::EC.generate(elliptic_curve)
       else
         raise ArgumentError, "Key type #{key_type} is not supported"
       end
     end
 
-    # Generate a new key pair with the same algorithm and key size as existing one
+    # Generate a new key pair with the same type and key size / curve as existing one
     def regenerate_private_key(template)
       case template
       when OpenSSL::PKey::RSA

--- a/lib/acmesmith/client.rb
+++ b/lib/acmesmith/client.rb
@@ -21,27 +21,9 @@ module Acmesmith
       key
     end
 
-    def order(*identifiers, not_before: nil, not_after: nil)
-      order = OrderingService.new(
-        acme: acme,
-        identifiers: identifiers,
-        challenge_responder_rules: config.challenge_responders,
-        chain_preferences: config.chain_preferences,
-        not_before: not_before,
-        not_after: not_after
-      )
-      order.perform!
-      cert = order.certificate
-
-      puts
-      print " * securing into the storage ..."
-      storage.put_certificate(cert, certificate_key_passphrase)
-      puts " [ ok ]"
-      puts
-
-      execute_post_issue_hooks(cert)
-
-      cert
+    def order(*identifiers, key_type: 'rsa', rsa_key_size: 2048, elliptic_curve: 'prime256v1', not_before: nil, not_after: nil)
+      private_key = generate_private_key(key_type: key_type, rsa_key_size: rsa_key_size, elliptic_curve: elliptic_curve)
+      order_with_private_key(*identifiers, private_key: private_key, not_before: not_before, not_after: not_after)
     end
 
     def authorize(*identifiers)
@@ -149,7 +131,7 @@ module Acmesmith
         puts "   Not valid after: #{not_after}"
         next unless (cert.certificate.not_after.utc - Time.now.utc) < (days.to_i * 86400)
         puts " * Renewing: CN=#{cert.common_name}, SANs=#{cert.sans.join(',')}"
-        order(cert.common_name, *cert.sans)
+        order_with_private_key(cert.common_name, *cert.sans, private_key: regenerate_private_key(cert.public_key))
       end
     end
 
@@ -158,7 +140,7 @@ module Acmesmith
       cert = storage.get_certificate(common_name)
       sans = cert.sans + add_sans
       puts " * SANs will be: #{sans.join(?,)}"
-      order(cert.common_name, *sans)
+      order_with_private_key(cert.common_name, *sans, private_key: regenerate_private_key(cert.public_key))
     end
 
     private
@@ -195,6 +177,53 @@ module Acmesmith
         ENV['ACMESMITH_ACCOUNT_KEY_PASSPHRASE'] || config['account_key_passphrase']
       else
         config['account_key_passphrase']
+      end
+    end
+
+    def order_with_private_key(*identifiers, private_key:, not_before: nil, not_after: nil)
+      order = OrderingService.new(
+        acme: acme,
+        identifiers: identifiers,
+        private_key: private_key,
+        challenge_responder_rules: config.challenge_responders,
+        chain_preferences: config.chain_preferences,
+        not_before: not_before,
+        not_after: not_after
+      )
+      order.perform!
+      cert = order.certificate
+
+      puts
+      print " * securing into the storage ..."
+      storage.put_certificate(cert, certificate_key_passphrase)
+      puts " [ ok ]"
+      puts
+
+      execute_post_issue_hooks(cert)
+
+      cert
+    end
+
+    def generate_private_key(key_type:, rsa_key_size:, elliptic_curve:)
+      case key_type
+      when 'rsa'
+        OpenSSL::PKey::RSA.generate(rsa_key_size)
+      when 'ecdsa'
+        OpenSSL::PKey::EC.generate(elliptic_curve)
+      else
+        raise ArgumentError, "Key type #{key_type} is not supported"
+      end
+    end
+
+    # Generate a new key pair with the same algorithm and key size as existing one
+    def regenerate_private_key(template)
+      case template
+      when OpenSSL::PKey::RSA
+        OpenSSL::PKey::RSA.generate(template.n.num_bits)
+      when OpenSSL::PKey::EC
+        OpenSSL::PKey::EC.generate(template.group)
+      else
+        raise ArgumentError, "Unknown key type: #{template.class}"
       end
     end
   end

--- a/lib/acmesmith/command.rb
+++ b/lib/acmesmith/command.rb
@@ -32,9 +32,9 @@ module Acmesmith
 
     desc "order COMMON_NAME [SAN]", "order certificate for CN +COMMON_NAME+ with SANs +SAN+"
     method_option :show_certificate, type: :boolean, aliases: %w(-s), default: true, desc: 'show an issued certificate in PEM and text when exiting'
-    method_option :key_type, type: :string, enum: %w(rsa ecdsa), default: 'rsa', desc: 'key algorithm'
+    method_option :key_type, type: :string, enum: %w(rsa ec), default: 'rsa', desc: 'key type'
     method_option :rsa_key_size, type: :numeric, default: 2048, desc: 'size of RSA key'
-    method_option :elliptic_curve, type: :string, default: 'prime256v1', desc: 'elliptic curve group for ECDSA key'
+    method_option :elliptic_curve, type: :string, default: 'prime256v1', desc: 'elliptic curve group for EC key'
     def order(common_name, *sans)
       cert = client.order(
         common_name, *sans,

--- a/lib/acmesmith/command.rb
+++ b/lib/acmesmith/command.rb
@@ -32,8 +32,16 @@ module Acmesmith
 
     desc "order COMMON_NAME [SAN]", "order certificate for CN +COMMON_NAME+ with SANs +SAN+"
     method_option :show_certificate, type: :boolean, aliases: %w(-s), default: true, desc: 'show an issued certificate in PEM and text when exiting'
+    method_option :key_type, type: :string, enum: %w(rsa ecdsa), default: 'rsa', desc: 'key algorithm'
+    method_option :rsa_key_size, type: :numeric, default: 2048, desc: 'size of RSA key'
+    method_option :elliptic_curve, type: :string, default: 'prime256v1', desc: 'elliptic curve group for ECDSA key'
     def order(common_name, *sans)
-      cert = client.order(common_name, *sans)
+      cert = client.order(
+        common_name, *sans,
+        key_type: options[:key_type],
+        rsa_key_size: options[:rsa_key_size],
+        elliptic_curve: options[:elliptic_curve],
+      )
       if options[:show_certificate]
         puts cert.certificate.to_text
         puts cert.certificate.to_pem

--- a/lib/acmesmith/ordering_service.rb
+++ b/lib/acmesmith/ordering_service.rb
@@ -8,20 +8,22 @@ module Acmesmith
 
     # @param acme [Acme::Client] ACME client
     # @param identifiers [Array<String>] Array of domain names for a ordering certificate. The first item will be a common name.
+    # @param private_key [OpenSSL::PKey::PKey] Private key
     # @param challenge_responder_rules [Array<Acmesmith::Config::ChallengeResponderRule>] responders
     # @param chain_preferences [Array<Acmesmith::Config::ChainPreference>] chain_preferences
     # @param not_before [Time]
     # @param not_after [Time]
-    def initialize(acme:, identifiers:, challenge_responder_rules:, chain_preferences:, not_before: nil, not_after: nil)
+    def initialize(acme:, identifiers:, private_key:, challenge_responder_rules:, chain_preferences:, not_before: nil, not_after: nil)
       @acme = acme
       @identifiers = identifiers
+      @private_key = private_key
       @challenge_responder_rules = challenge_responder_rules
       @chain_preferences = chain_preferences
       @not_before = not_before
       @not_after = not_after
     end
 
-    attr_reader :acme, :identifiers, :challenge_responder_rules, :chain_preferences, :not_before, :not_after
+    attr_reader :acme, :identifiers, :private_key, :challenge_responder_rules, :chain_preferences, :not_before, :not_after
 
     def perform!
       puts "=> Ordering a certificate for the following identifiers:"
@@ -107,7 +109,7 @@ module Acmesmith
 
     # @return [Acme::Client::CertificateRequest]
     def csr
-      @csr ||= Acme::Client::CertificateRequest.new(subject: { common_name: common_name }, names: sans)
+      @csr ||= Acme::Client::CertificateRequest.new(subject: { common_name: common_name }, names: sans, private_key: private_key)
     end
   end
 end

--- a/spec/integration/pebble/pebble_spec.rb
+++ b/spec/integration/pebble/pebble_spec.rb
@@ -104,6 +104,34 @@ RSpec.describe "Integration with Pebble", integration_pebble: true do
     end
   end
 
+  context "ECDSA key" do
+    it "works" do
+      system(*cmd("order", "ecdsa.invalid", "--key-type", "ecdsa", "--elliptic-curve", "prime256v1"), exception: true)
+
+      certificate = OpenSSL::X509::Certificate.new(IO.popen(cmd("show-certificate", "--type=certificate", "ecdsa.invalid")))
+      expect(certificate.public_key.group.curve_name).to eq "prime256v1"
+
+      system(*cmd("add-san", "ecdsa.invalid", "san.invalid"), exception: true)
+
+      certificate = OpenSSL::X509::Certificate.new(IO.popen(cmd("show-certificate", "--type=certificate", "ecdsa.invalid")))
+      expect(certificate.public_key.group.curve_name).to eq "prime256v1"  # new cert has the same curve
+    end
+  end
+
+  context "RSA3072 key" do
+    it "works" do
+      system(*cmd("order", "rsa3072.invalid", "--key-type", "rsa", "--rsa-key-size", "3072"), exception: true)
+
+      certificate = OpenSSL::X509::Certificate.new(IO.popen(cmd("show-certificate", "--type=certificate", "rsa3072.invalid")))
+      expect(certificate.public_key.n.num_bits).to eq 3072
+
+      system(*cmd("add-san", "rsa3072.invalid", "san.invalid"), exception: true)
+
+      certificate = OpenSSL::X509::Certificate.new(IO.popen(cmd("show-certificate", "--type=certificate", "rsa3072.invalid")))
+      expect(certificate.public_key.n.num_bits).to eq 3072  # new cert has the same key length
+    end
+  end
+
   context "post_issue_hooks" do
     it "works" do
       system(*cmd("order", "flag.invalid"), exception: true)

--- a/spec/integration/pebble/pebble_spec.rb
+++ b/spec/integration/pebble/pebble_spec.rb
@@ -104,9 +104,9 @@ RSpec.describe "Integration with Pebble", integration_pebble: true do
     end
   end
 
-  context "ECDSA key" do
+  context "EC key" do
     it "works" do
-      system(*cmd("order", "ecdsa.invalid", "--key-type", "ecdsa", "--elliptic-curve", "prime256v1"), exception: true)
+      system(*cmd("order", "ecdsa.invalid", "--key-type", "ec", "--elliptic-curve", "prime256v1"), exception: true)
 
       certificate = OpenSSL::X509::Certificate.new(IO.popen(cmd("show-certificate", "--type=certificate", "ecdsa.invalid")))
       expect(certificate.public_key.group.curve_name).to eq "prime256v1"


### PR DESCRIPTION
This patch adds three command-line options for `acmesmith order` to specify the public key algorithm for the certificate to be requested.

- `--key-type` specifies the type of generated keypair. Supported values are `rsa` and `ecdsa` (default: `rsa`)
- `--rsa-key-size` specifies the RSA modulus size in bits (default: `2048`)
- `--elliptic-curve` specifies the ECDSA curve group. Possible values are up to the linked OpenSSL and the CA. (default: `prime256v1`)

The default values match the current behaviour (RSA 2048 bits).

When a certificate is initially ordered, Acmesmith generates a keypair of the type and the key size / elliptic curve given in the command line. On subsequent renewals, a fresh keypair of the same algorithm and the size as the existing public key is used to order a new certificate.
