### PR TITLE
ordering_service: normalize ip identifiers

### DIFF
--- a/lib/acmesmith/ordering_service.rb
+++ b/lib/acmesmith/ordering_service.rb
@@ -141,8 +141,8 @@ module Acmesmith
       end
 
       begin
-        IPAddr.new(name)  # Test if it parses
-        { type: 'ip', value: name }
+        addr = IPAddr.new(name)
+        { type: 'ip', value: addr.to_s }  # IPAddr#to_s normalizes IPv6 address to RFC 5952 form as required by RFC 8738 \S 3
       rescue IPAddr::InvalidAddressError
         { type: 'dns', value: name }
       end


### PR DESCRIPTION
RFC 8738 requires IPv6 identifiers to follow the textual form defined in RFC 5952 §4 (lowercase hex, compressed). The raw input string was previously sent as-is to the CA.

This causes renewal to fail when a certificate was previously issued with an IPv6 SAN: OpenSSL renders IPv6 addresses with uppercase hex digits, so when acmesmith reads the existing certificate's SANs to build the renewal order, the uppercase form is passed through unchanged and rejected by the CA as a malformed identifier.

Fixup: https://github.com/sorah/acmesmith/pull/83